### PR TITLE
✨ add support for the @requires directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ import { GraphQLReferenceResolver } from '@apollo/federation/dist/types';
 interface FederationFieldConfig {
   external?: boolean;
   provides?: string;
+  requires?: string;
 }
 
 interface FederationFieldsConfig {
@@ -136,11 +137,3 @@ Runs the example in watch mode for development.
 ## `npm run test`
 
 Run the tests
-
-## The `requires` directive
-
-When extending an existing type you can resolve derived properties using
-[the `requires` directive](https://www.apollographql.com/docs/apollo-server/federation/advanced-features/#computed-fields).
-When you have an existing schema that you want to transform to a federated
-schema I'm not sure what you would use if for. So unless I learn of a real world
-usecase, I can't implement the `requires` directive.

--- a/src/transform-federation.ts
+++ b/src/transform-federation.ts
@@ -18,6 +18,7 @@ import {
 export interface FederationFieldConfig {
   external?: boolean;
   provides?: string;
+  requires?: string;
 }
 
 export interface FederationFieldsConfig {

--- a/src/transform-sdl.spec.ts
+++ b/src/transform-sdl.spec.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { addFederationAnnotations } from './transform-sdl';
 
-describe('transform-federation', () => {
+describe('transform-sdl', () => {
   it('should add key directives to sdl', () => {
     expect(
       addFederationAnnotations(
@@ -75,6 +75,7 @@ describe('transform-federation', () => {
               id: {
                 external: true,
                 provides: 'mock provides',
+                requires: 'a { query }'
               },
             },
           },
@@ -82,7 +83,7 @@ describe('transform-federation', () => {
       ),
     ).toEqual(dedent`
       type Product {
-        id: Int @external @provides(fields: "mock provides")
+        id: Int @external @provides(fields: "mock provides") @requires(fields: "a { query }")
       }\n`);
   });
 
@@ -103,12 +104,15 @@ describe('transform-federation', () => {
               field2: {
                 provides: 'mock provides',
               },
+              field3: {
+                requires: 'mock requires',
+              },
             },
           },
         },
       );
     }).toThrow(
-      'Could not add directive to these fields: NotProduct.field1, NotProduct.field2',
+      'Could not add directive to these fields: NotProduct.field1, NotProduct.field2, NotProduct.field3',
     );
   });
 });

--- a/src/transform-sdl.ts
+++ b/src/transform-sdl.ts
@@ -23,8 +23,9 @@ function createDirectiveWithFields(directiveName: string, fields: string) {
 function isFieldConfigToDo({
   external,
   provides,
+  requires,
 }: FederationFieldConfig): boolean {
-  return Boolean(external || provides);
+  return Boolean(external || provides || requires);
 }
 
 function filterFieldsConfigToDo(
@@ -122,6 +123,14 @@ export function addFederationAnnotations<TContext>(
                   createDirectiveWithFields(
                     'provides',
                     currentFieldConfig.provides,
+                  ),
+                ]
+              : []),
+            ...(currentFieldConfig.requires
+              ? [
+                  createDirectiveWithFields(
+                    'requires',
+                    currentFieldConfig.requires,
                   ),
                 ]
               : []),


### PR DESCRIPTION
## Motivation
https://github.com/0xR/graphql-transform-federation/issues/2 presents a different use-case for this library, one that entails the need for the `@requires` directive.

## Approach
Added support for the `@requires`, following the patterns established for the `@provides` directive (as they're remarkably similar).