### PR TITLE
allow hide fields and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ interface FederationFieldConfig {
   external?: boolean;
   provides?: string;
   requires?: string;
+  hidden?: boolean;
 }
 
 interface FederationFieldsConfig {
@@ -109,6 +110,7 @@ interface FederationObjectConfig<TContext> {
   extend?: boolean;
   resolveReference?: GraphQLReferenceResolver<TContext>;
   fields?: FederationFieldsConfig;
+  hidden?: boolean;
 }
 
 interface FederationConfig<TContext> {
@@ -137,3 +139,25 @@ Runs the example in watch mode for development.
 ## `npm run test`
 
 Run the tests
+
+# Hiding unwanted fields and types
+
+In case you have no control over remote schema and there are fields with same name you gonna need to hide them from gateway
+
+You can hide both fields and types like so:
+
+```typescript
+const federationSchema = transformSchemaFederation(schemaWithoutFederation, {
+  Query: {
+    extend: true,
+    fields: {
+      someUnwantedField: {
+        hidden: true // will be not visible for gateway
+      }
+    }
+  },
+  SomeUnwantedType: {
+    hidden: true // will be not visible for gateway
+  },
+});
+```

--- a/src/transform-federation.ts
+++ b/src/transform-federation.ts
@@ -19,6 +19,7 @@ export interface FederationFieldConfig {
   external?: boolean;
   provides?: string;
   requires?: string;
+  hidden?: boolean;
 }
 
 export interface FederationFieldsConfig {
@@ -30,6 +31,7 @@ export interface FederationObjectConfig<TContext> {
   extend?: boolean;
   resolveReference?: GraphQLReferenceResolver<TContext>;
   fields?: FederationFieldsConfig;
+  hidden?: boolean;
 }
 
 export interface FederationConfig<TContext> {

--- a/src/transform-sdl.spec.ts
+++ b/src/transform-sdl.spec.ts
@@ -115,4 +115,51 @@ describe('transform-sdl', () => {
       'Could not add directive to these fields: NotProduct.field1, NotProduct.field2, NotProduct.field3',
     );
   });
+
+  it('should remove hidden fields from sdl', () => {
+    expect(
+      addFederationAnnotations(
+        `
+      type Query {
+        hello: String
+        ok: Boolean
+      }`,
+        {
+          Query: {
+            fields: {
+              ok: {
+                hidden: true
+              }
+            }
+          },
+        },
+      ),
+    ).toEqual(dedent`
+      type Query {
+        hello: String
+      }\n`);
+  });
+
+  it('should remove hidden types from sdl', () => {
+    expect(
+      addFederationAnnotations(
+        `
+      type Query {
+        hello: String
+      }
+      
+      type Unwanted {
+        id: Int
+      }`,
+        {
+          Unwanted: {
+            hidden: true
+          },
+        },
+      ),
+    ).toEqual(dedent`
+      type Query {
+        hello: String
+      }\n`);
+  });
 });


### PR DESCRIPTION
According to #1 and my founding we gonna need to be able to hide fields exactly inside this transform not before (wont be able to delegate) not after (gateway wont work)

What have I done in this PR:

1. Added `hidden` to both `FederationFieldConfig` and `FederationObjectConfig`
2. Added `null` as possible return type to `visitor` - according to [spec](https://graphql.org/graphql-js/language/#visit) if we return null node will be removed 
3. Simple if statements to check whether current node is unwanted which return null

Test and readme also included

Hope to see it somewhere in near future in your library it will help us move further and connect everything into one beautiful graph without this hacky ways to remove unwanted fields

BR
Alex